### PR TITLE
Refactor theme usage

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -9,33 +9,7 @@ import QuarterlySnapshot from "./QuarterlySnapshot";
 import UnpaidInvoicesList from "./UnpaidInvoicesList";
 import DashboardCharts from "./DashboardCharts";
 import type { FirmType } from "../types";
-
-const firmThemes = {
-  SKALLARS: {
-    primary: "bg-purple-100",
-    secondary: "bg-purple-50",
-    text: "text-purple-600",
-    border: "border-purple-200",
-    light: "text-purple-500",
-    accent: "#9333ea",
-  },
-  MKMs: {
-    primary: "bg-blue-100",
-    secondary: "bg-blue-50",
-    text: "text-blue-600",
-    border: "border-blue-200",
-    light: "text-blue-500",
-    accent: "#2563eb",
-  },
-  Contax: {
-    primary: "bg-yellow-100",
-    secondary: "bg-yellow-50",
-    text: "text-yellow-600",
-    border: "border-yellow-200",
-    light: "text-yellow-500",
-    accent: "#d97706",
-  },
-} as const;
+import { firmStyles } from "../theme/firmStyles";
 
 export default function Dashboard() {
   const { user, logout } = useAuth();
@@ -44,7 +18,7 @@ export default function Dashboard() {
 
   if (!user) return null;
 
-  const firmTheme = firmThemes[user.firm as FirmType];
+  const firmTheme = firmStyles[user.firm as FirmType];
 
   const quarterLabel = `Q${currentQuarter} ${currentYear}`;
   const quarterRange = {
@@ -58,7 +32,7 @@ export default function Dashboard() {
   })}`;
 
   return (
-    <div className={`min-h-screen ${firmTheme.secondary}`}>
+    <div className={`min-h-screen ${firmTheme.bg}`}>
       {/* Header */}
       <header className="bg-white shadow-sm">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/src/components/DashboardCharts.tsx
+++ b/src/components/DashboardCharts.tsx
@@ -27,27 +27,7 @@ import {
   ArrowDownRight,
 } from "lucide-react";
 import type { FirmType } from "../types";
-
-const firmThemes = {
-  SKALLARS: {
-    primary: "#9333ea",
-    secondary: "#a855f7",
-    tertiary: "#c084fc",
-    light: "#f3e8ff",
-  },
-  MKMs: {
-    primary: "#2563eb",
-    secondary: "#3b82f6",
-    tertiary: "#60a5fa",
-    light: "#e0f2fe",
-  },
-  Contax: {
-    primary: "#d97706",
-    secondary: "#f59e0b",
-    tertiary: "#fbbf24",
-    light: "#fef3c7",
-  },
-} as const;
+import { firmStyles } from "../theme/firmStyles";
 
 interface ChartMetric {
   label: string;
@@ -234,7 +214,7 @@ export default function DashboardCharts() {
 
   if (!user) return null;
 
-  const theme = firmThemes[user.firm];
+  const theme = firmStyles[user.firm].chartColors;
 
   return (
     <div className="space-y-6">

--- a/src/components/InvoiceList.tsx
+++ b/src/components/InvoiceList.tsx
@@ -18,27 +18,7 @@ import {
   ChevronUp,
 } from "lucide-react";
 import type { FirmType, Invoice } from "../types";
-
-const firmThemes = {
-  SKALLARS: {
-    bg: "bg-purple-50",
-    border: "border-purple-200",
-    text: "text-purple-600",
-    hover: "hover:bg-purple-100",
-  },
-  MKMs: {
-    bg: "bg-blue-50",
-    border: "border-blue-200",
-    text: "text-blue-600",
-    hover: "hover:bg-blue-100",
-  },
-  Contax: {
-    bg: "bg-yellow-50",
-    border: "border-yellow-200",
-    text: "text-yellow-600",
-    hover: "hover:bg-yellow-100",
-  },
-} as const;
+import { firmStyles } from "../theme/firmStyles";
 
 interface FilterState {
   search: string;
@@ -126,7 +106,7 @@ function InvoiceCard({
   onEdit,
   userFirm,
 }: InvoiceCardProps) {
-  const theme = firmThemes[invoice.invoicedByFirm];
+  const theme = firmStyles[invoice.invoicedByFirm];
   const isOverdue =
     !invoice.isPaid &&
     new Date(invoice.date).getTime() < Date.now() - 30 * 24 * 60 * 60 * 1000;

--- a/src/components/QuarterlySnapshot.tsx
+++ b/src/components/QuarterlySnapshot.tsx
@@ -13,24 +13,7 @@ import {
 } from "lucide-react";
 import QuarterYearSelector from "./QuarterYearSelector";
 import type { FirmType } from "../types";
-
-const firmThemes = {
-  SKALLARS: {
-    light: "bg-purple-50",
-    border: "border-purple-200",
-    text: "text-purple-600",
-  },
-  MKMs: {
-    light: "bg-blue-50",
-    border: "border-blue-200",
-    text: "text-blue-600",
-  },
-  Contax: {
-    light: "bg-yellow-50",
-    border: "border-yellow-200",
-    text: "text-yellow-600",
-  },
-} as const;
+import { firmStyles } from "../theme/firmStyles";
 
 interface UnpaidQuarterInfo {
   quarter: string;
@@ -62,7 +45,7 @@ function CommissionCard({
   direction: "receivable" | "payable";
   userFirm: FirmType;
 }) {
-  const theme = firmThemes[firm];
+  const theme = firmStyles[firm];
 
   return (
     <div

--- a/src/components/QuarterlySummary.tsx
+++ b/src/components/QuarterlySummary.tsx
@@ -3,33 +3,7 @@ import { useInvoices } from "../context/InvoiceContext";
 import { useAuth } from "../context/AuthContext";
 import { ArrowRight, Euro, Clock, Check } from "lucide-react";
 import type { FirmType } from "../types";
-
-const firmThemes = {
-  SKALLARS: {
-    primary: "bg-purple-100",
-    secondary: "bg-purple-50",
-    text: "text-purple-600",
-    accent: "bg-purple-600",
-    border: "border-purple-200",
-    gradient: "from-purple-50 to-purple-100",
-  },
-  MKMs: {
-    primary: "bg-gray-100",
-    secondary: "bg-gray-50",
-    text: "text-gray-600",
-    accent: "bg-gray-600",
-    border: "border-gray-200",
-    gradient: "from-gray-50 to-gray-100",
-  },
-  Contax: {
-    primary: "bg-yellow-100",
-    secondary: "bg-yellow-50",
-    text: "text-yellow-600",
-    accent: "bg-yellow-600",
-    border: "border-yellow-200",
-    gradient: "from-yellow-50 to-yellow-100",
-  },
-};
+import { firmStyles } from "../theme/firmStyles";
 
 interface QuarterlyData {
   quarter: string;
@@ -69,12 +43,12 @@ function FirmSummaryCard({
   return (
     <div
       className={`
-      rounded-lg border ${firmThemes[firm].border}
-      bg-gradient-to-br ${firmThemes[firm].gradient}
+      rounded-lg border ${firmStyles[firm].border}
+      bg-gradient-to-br ${firmStyles[firm].gradient}
     `}
     >
       <div className="p-6">
-        <h3 className={`text-lg font-semibold ${firmThemes[firm].text}`}>
+        <h3 className={`text-lg font-semibold ${firmStyles[firm].text}`}>
           {firm}
         </h3>
 
@@ -95,7 +69,7 @@ function FirmSummaryCard({
                   >
                     <div className="flex items-center justify-between text-sm">
                       <div className="flex items-center">
-                        <span className={firmThemes[fromFirm as FirmType].text}>
+                        <span className={firmStyles[fromFirm as FirmType].text}>
                           {fromFirm}
                         </span>
                         <ArrowRight className="h-3 w-3 mx-1 text-gray-400" />
@@ -133,7 +107,7 @@ function FirmSummaryCard({
                     <div className="flex items-center justify-between text-sm">
                       <div className="flex items-center">
                         <Euro className="h-3 w-3 mr-1 text-gray-400" />
-                        <span className={firmThemes[toFirm as FirmType].text}>
+                        <span className={firmStyles[toFirm as FirmType].text}>
                           {toFirm}
                         </span>
                         <span className="mx-1">·</span>
@@ -252,7 +226,7 @@ export default function QuarterlySummary() {
       </h2>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        {Object.keys(firmThemes).map((firm) => (
+        {Object.keys(firmStyles).map((firm) => (
           <FirmSummaryCard
             key={firm}
             firm={firm as FirmType}

--- a/src/components/RecentInvoices.tsx
+++ b/src/components/RecentInvoices.tsx
@@ -9,24 +9,7 @@ import {
   Clock,
 } from "lucide-react";
 import type { FirmType } from "../types";
-
-const firmThemes = {
-  SKALLARS: {
-    text: "text-purple-600",
-    bg: "bg-purple-50",
-    border: "border-purple-200",
-  },
-  MKMs: {
-    text: "text-blue-600",
-    bg: "bg-blue-50",
-    border: "border-blue-200",
-  },
-  Contax: {
-    text: "text-yellow-600",
-    bg: "bg-yellow-50",
-    border: "border-yellow-200",
-  },
-} as const;
+import { firmStyles } from "../theme/firmStyles";
 
 interface RecentInvoiceProps {
   clientName: string;
@@ -45,7 +28,7 @@ function RecentInvoiceRow({
   commissionPercentage,
   referredByFirm,
 }: RecentInvoiceProps) {
-  const theme = firmThemes[referredByFirm];
+  const theme = firmStyles[referredByFirm];
   const formattedAmount = new Intl.NumberFormat("de-DE", {
     style: "currency",
     currency: "EUR",

--- a/src/components/UnpaidInvoicesList.tsx
+++ b/src/components/UnpaidInvoicesList.tsx
@@ -14,27 +14,7 @@ import {
   Filter,
 } from "lucide-react";
 import type { FirmType } from "../types";
-
-const firmThemes = {
-  SKALLARS: {
-    bg: "bg-purple-50",
-    border: "border-purple-200",
-    text: "text-purple-600",
-    hover: "hover:bg-purple-100",
-  },
-  MKMs: {
-    bg: "bg-blue-50",
-    border: "border-blue-200",
-    text: "text-blue-600",
-    hover: "hover:bg-blue-100",
-  },
-  Contax: {
-    bg: "bg-yellow-50",
-    border: "border-yellow-200",
-    text: "text-yellow-600",
-    hover: "hover:bg-yellow-100",
-  },
-} as const;
+import { firmStyles } from "../theme/firmStyles";
 
 interface Invoice {
   id: string;
@@ -113,7 +93,7 @@ function UnpaidInvoiceCard({
   userFirm,
   daysOverdue,
 }: UnpaidInvoiceCardProps) {
-  const theme = firmThemes[invoice.invoicedByFirm];
+  const theme = firmStyles[invoice.invoicedByFirm];
   const isUsersFirm = userFirm === invoice.invoicedByFirm;
   const commission = (invoice.amount * invoice.commissionPercentage) / 100;
 
@@ -179,11 +159,11 @@ function UnpaidInvoiceCard({
         </div>
         <div className="flex items-center text-gray-500">
           <Building className="h-4 w-4 mr-2" />
-          <span className={firmThemes[invoice.invoicedByFirm].text}>
+          <span className={firmStyles[invoice.invoicedByFirm].text}>
             {invoice.invoicedByFirm}
           </span>
           <ChevronRight className="h-4 w-4 mx-1" />
-          <span className={firmThemes[invoice.referredByFirm].text}>
+          <span className={firmStyles[invoice.referredByFirm].text}>
             {invoice.referredByFirm}
           </span>
         </div>

--- a/src/theme/firmStyles.ts
+++ b/src/theme/firmStyles.ts
@@ -1,0 +1,62 @@
+import type { FirmType } from "../types";
+
+export const firmStyles: Record<FirmType, {
+  bg: string;
+  bgLight: string;
+  border: string;
+  text: string;
+  hover: string;
+  accent: string;
+  lightText: string;
+  gradient?: string;
+  chartColors: { primary: string; secondary: string; tertiary: string; light: string };
+}> = {
+  SKALLARS: {
+    bg: "bg-purple-50",
+    bgLight: "bg-purple-100",
+    border: "border-purple-200",
+    text: "text-purple-600",
+    hover: "hover:bg-purple-100",
+    accent: "#9333ea",
+    lightText: "text-purple-500",
+    gradient: "from-purple-50 to-purple-100",
+    chartColors: {
+      primary: "#9333ea",
+      secondary: "#a855f7",
+      tertiary: "#c084fc",
+      light: "#f3e8ff",
+    },
+  },
+  MKMs: {
+    bg: "bg-blue-50",
+    bgLight: "bg-blue-100",
+    border: "border-blue-200",
+    text: "text-blue-600",
+    hover: "hover:bg-blue-100",
+    accent: "#2563eb",
+    lightText: "text-blue-500",
+    gradient: "from-gray-50 to-gray-100",
+    chartColors: {
+      primary: "#2563eb",
+      secondary: "#3b82f6",
+      tertiary: "#60a5fa",
+      light: "#e0f2fe",
+    },
+  },
+  Contax: {
+    bg: "bg-yellow-50",
+    bgLight: "bg-yellow-100",
+    border: "border-yellow-200",
+    text: "text-yellow-600",
+    hover: "hover:bg-yellow-100",
+    accent: "#d97706",
+    lightText: "text-yellow-500",
+    gradient: "from-yellow-50 to-yellow-100",
+    chartColors: {
+      primary: "#d97706",
+      secondary: "#f59e0b",
+      tertiary: "#fbbf24",
+      light: "#fef3c7",
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- centralize firm-specific Tailwind classes and chart colours
- use the new mapping across dashboard components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683feb7843988320bcf257ef24cc4e26