### PR TITLE
Fix some lint errors

### DIFF
--- a/src/components/DashboardCharts.tsx
+++ b/src/components/DashboardCharts.tsx
@@ -26,7 +26,6 @@ import {
   ArrowUpRight,
   ArrowDownRight,
 } from "lucide-react";
-import type { FirmType } from "../types";
 
 const firmThemes = {
   SKALLARS: {
@@ -55,6 +54,13 @@ interface ChartMetric {
   change: number;
   trend: "up" | "down";
   icon: React.ElementType;
+}
+
+interface MonthlyData {
+  month: string;
+  revenue: number;
+  commissions: number;
+  count: number;
 }
 
 function MetricCard({ metric }: { metric: ChartMetric }) {
@@ -180,7 +186,7 @@ export default function DashboardCharts() {
     ];
   }, [filteredInvoices]);
 
-  const monthlyData = useMemo(() => {
+  const monthlyData: MonthlyData[] = useMemo(() => {
     const data = filteredInvoices.reduce(
       (acc, invoice) => {
         const date = new Date(invoice.date);
@@ -206,7 +212,7 @@ export default function DashboardCharts() {
 
         return acc;
       },
-      {} as Record<string, any>,
+      {} as Record<string, MonthlyData>,
     );
 
     return Object.values(data).sort(
@@ -243,7 +249,11 @@ export default function DashboardCharts() {
         {["1M", "3M", "6M", "1Y", "ALL"].map((range) => (
           <button
             key={range}
-            onClick={() => setSelectedTimeRange(range as any)}
+            onClick={() =>
+              setSelectedTimeRange(
+                range as "1M" | "3M" | "6M" | "1Y" | "ALL"
+              )
+            }
             className={`px-3 py-1 rounded-md text-sm font-medium transition-colors
               ${
                 selectedTimeRange === range

--- a/src/components/EditInvoiceModal.tsx
+++ b/src/components/EditInvoiceModal.tsx
@@ -3,12 +3,12 @@ import { X } from "lucide-react";
 import CustomDropdown from "./common/CustomDropdown";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
-import type { FirmType } from "../types";
+import type { FirmType, Invoice } from "../types";
 
 interface EditInvoiceModalProps {
-  invoice: any;
+  invoice: Invoice;
   onClose: () => void;
-  onSave: (updatedInvoice: any) => void;
+  onSave: (updatedInvoice: Invoice) => void;
   userFirm: FirmType;
 }
 

--- a/src/components/InvoiceForm.tsx
+++ b/src/components/InvoiceForm.tsx
@@ -35,7 +35,7 @@ const INITIAL_FORM_DATA = (userFirm: FirmType): FormData => {
 export default function InvoiceForm() {
   const { user } = useAuth();
   const { addInvoice } = useInvoices();
-  const { addClient, searchClients } = useClient();
+  const { addClient } = useClient();
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<boolean>(false);
 
@@ -82,7 +82,7 @@ export default function InvoiceForm() {
 
       // Reset success message after 3 seconds
       setTimeout(() => setSuccess(false), 3000);
-    } catch (err) {
+    } catch {
       setError("Failed to create invoice. Please try again.");
     }
   };
@@ -220,3 +220,4 @@ export default function InvoiceForm() {
     </form>
   );
 }
+

--- a/src/components/InvoiceList.tsx
+++ b/src/components/InvoiceList.tsx
@@ -17,6 +17,7 @@ import {
   ChevronDown,
   ChevronUp,
 } from "lucide-react";
+import { formatCurrency } from "../lib/utils";
 import type { FirmType, Invoice } from "../types";
 
 const firmThemes = {
@@ -157,7 +158,7 @@ function InvoiceCard({
             <div className="text-right">
               <p className="text-lg font-semibold flex items-center">
                 <Euro className="w-4 h-4 mr-1" />
-                {formatCurrency(invoice.amount)}
+                {formatCurrency(invoice.amount, { locale: 'en-US', showCurrency: false, minimumFractionDigits: 2, maximumFractionDigits: 2 })}
               </p>
               <StatusBadge status={invoice.isPaid ? 'paid' : isOverdue ? 'overdue' : 'pending'} />
             </div>
@@ -206,9 +207,12 @@ function InvoiceCard({
                 <p className="text-sm text-gray-500">Commission</p>
                 <p className="font-medium">
                   {invoice.commissionPercentage}% (€
-                  {formatCurrency(
-                    (invoice.amount * invoice.commissionPercentage) / 100
-                  )}
+                  {formatCurrency((invoice.amount * invoice.commissionPercentage) / 100, {
+                    locale: 'en-US',
+                    showCurrency: false,
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  })}
                   )
                 </p>
               </div>
@@ -420,11 +424,4 @@ export default function InvoiceList() {
       )}
     </div>
   );
-}
-
-function formatCurrency(amount: number): string {
-  return new Intl.NumberFormat("en-US", {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(amount);
 }

--- a/src/components/InvoiceSummary.tsx
+++ b/src/components/InvoiceSummary.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { AlertCircle, Clock, CheckCircle } from 'lucide-react';
+import { formatCurrency } from '../lib/utils';
 
 interface InvoiceSummaryProps {
   totalInvoices: number;
@@ -20,13 +21,6 @@ export default function InvoiceSummary({
   pendingAmount,
   overdueAmount,
 }: InvoiceSummaryProps) {
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'EUR',
-      minimumFractionDigits: 2,
-    }).format(amount);
-  };
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
@@ -42,7 +36,7 @@ export default function InvoiceSummary({
           </div>
         </div>
         <p className="mt-2 text-sm text-gray-500">
-          Total Value: {formatCurrency(totalAmount)}
+          Total Value: {formatCurrency(totalAmount, { locale: 'en-US', currency: 'EUR' })}
         </p>
       </div>
 
@@ -74,7 +68,7 @@ export default function InvoiceSummary({
           </div>
         </div>
         <p className="mt-2 text-sm text-gray-500">
-          Value: {formatCurrency(pendingAmount)}
+          Value: {formatCurrency(pendingAmount, { locale: 'en-US', currency: 'EUR' })}
         </p>
       </div>
 
@@ -90,7 +84,7 @@ export default function InvoiceSummary({
           </div>
         </div>
         <p className="mt-2 text-sm text-gray-500">
-          Value: {formatCurrency(overdueAmount)}
+          Value: {formatCurrency(overdueAmount, { locale: 'en-US', currency: 'EUR' })}
         </p>
       </div>
     </div>

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -32,8 +32,11 @@ export default function LoginForm() {
       } else {
         await login(email, password);
       }
-    } catch (err: any) {
-      const errorMessage = err.message || "Authentication failed. Please try again.";
+    } catch (err: unknown) {
+      const errorMessage =
+        err instanceof Error
+          ? err.message
+          : "Authentication failed. Please try again.";
       setError(errorMessage);
     }
   };
@@ -198,3 +201,4 @@ export default function LoginForm() {
     </div>
   );
 }
+

--- a/src/components/QuarterNavigation.tsx
+++ b/src/components/QuarterNavigation.tsx
@@ -15,14 +15,13 @@ interface QuarterNavigationProps {
   }>;
   selectedQuarter: string | null;
   onQuarterSelect: (quarterKey: string) => void;
-  userFirm: FirmType;
 }
 
-export function QuarterNavigation({ 
-  quarters, 
+export function QuarterNavigation({
+  quarters,
   selectedQuarter,
   onQuarterSelect,
-  userFirm
+
 }: QuarterNavigationProps) {
   return (
     <div className="flex flex-col space-y-4">
@@ -85,3 +84,4 @@ export function QuarterNavigation({
     </div>
   );
 }
+

--- a/src/components/QuarterlyCommissions.tsx
+++ b/src/components/QuarterlyCommissions.tsx
@@ -54,7 +54,7 @@ function QuarterlyCommissions() {
       const commission = invoice.amount * 0.1;
       
       // Find or create commission entry for the invoicing firm
-      let commissionEntry = data[quarterKey].eligibleCommissions.find(
+      const commissionEntry = data[quarterKey].eligibleCommissions.find(
         c => c.fromFirm === invoice.invoicedByFirm
       );
 

--- a/src/components/QuarterlySnapshot.tsx
+++ b/src/components/QuarterlySnapshot.tsx
@@ -11,6 +11,7 @@ import {
   AlertTriangle,
   ChevronRight,
 } from "lucide-react";
+import { formatCurrency } from "../lib/utils";
 import QuarterYearSelector from "./QuarterYearSelector";
 import type { FirmType } from "../types";
 
@@ -86,7 +87,7 @@ function CommissionCard({
           </>
         )}
       </div>
-      <div className="font-medium text-gray-900">{formatCurrency(amount)}</div>
+      <div className="font-medium text-gray-900">{formatCurrency(amount, { locale: 'de-DE', currency: 'EUR' })}</div>
     </div>
   );
 }
@@ -121,10 +122,10 @@ function UnpaidQuartersWarning({
                   </span>
                   <div className="ml-4 space-y-1">
                     {q.receivable > 0 && (
-                      <div>To receive: {formatCurrency(q.receivable)}</div>
+                      <div>To receive: {formatCurrency(q.receivable, { locale: 'de-DE', currency: 'EUR' })}</div>
                     )}
                     {q.payable > 0 && (
-                      <div>To pay: {formatCurrency(q.payable)}</div>
+                      <div>To pay: {formatCurrency(q.payable, { locale: 'de-DE', currency: 'EUR' })}</div>
                     )}
                   </div>
                 </div>
@@ -244,7 +245,7 @@ export default function QuarterlySnapshot() {
         <div className="p-4 bg-green-50 rounded-lg border border-green-200">
           <div className="text-sm font-medium text-green-700">To Receive</div>
           <div className="mt-2 text-2xl font-semibold text-gray-900">
-            {formatCurrency(quarterlyData.toReceive.total)}
+            {formatCurrency(quarterlyData.toReceive.total, { locale: 'de-DE', currency: 'EUR' })}
           </div>
           <div className="mt-1 text-sm text-green-600">
             From paid invoices only
@@ -254,7 +255,7 @@ export default function QuarterlySnapshot() {
         <div className="p-4 bg-blue-50 rounded-lg border border-blue-200">
           <div className="text-sm font-medium text-blue-700">To Pay</div>
           <div className="mt-2 text-2xl font-semibold text-gray-900">
-            {formatCurrency(quarterlyData.toPay.total)}
+            {formatCurrency(quarterlyData.toPay.total, { locale: 'de-DE', currency: 'EUR' })}
           </div>
           <div className="mt-1 text-sm text-blue-600">
             From paid invoices only
@@ -302,11 +303,4 @@ export default function QuarterlySnapshot() {
       </div>
     </div>
   );
-}
-
-function formatCurrency(amount: number): string {
-  return new Intl.NumberFormat("de-DE", {
-    style: "currency",
-    currency: "EUR",
-  }).format(amount);
 }

--- a/src/components/StatisticsOverview.tsx
+++ b/src/components/StatisticsOverview.tsx
@@ -34,13 +34,13 @@ export default function StatisticsOverview() {
     const currentY = now.getFullYear();
     const currentQKey = `${currentY}-Q${currentQ}`;
 
-    let quarterSummary: QuarterSummary = {
+    const quarterSummary: QuarterSummary = {
       revenue: 0,
       commissionsReceivable: 0,
       commissionPayable: 0,
     };
 
-    let pending = [];
+    const pending = [];
     
     invoices.forEach((invoice) => {
       const date = new Date(invoice.date);

--- a/src/components/UnpaidInvoicesList.tsx
+++ b/src/components/UnpaidInvoicesList.tsx
@@ -14,6 +14,7 @@ import {
   Filter,
 } from "lucide-react";
 import type { FirmType } from "../types";
+import { formatCurrency } from "../lib/utils";
 
 const firmThemes = {
   SKALLARS: {
@@ -163,10 +164,10 @@ function UnpaidInvoiceCard({
 
         <div className="text-right">
           <div className="font-medium text-gray-900">
-            {formatCurrency(invoice.amount)}
+            {formatCurrency(invoice.amount, { locale: 'de-DE', currency: 'EUR' })}
           </div>
           <div className="text-sm text-gray-500">
-            Commission: {formatCurrency(commission)}
+            Commission: {formatCurrency(commission, { locale: 'de-DE', currency: 'EUR' })}
           </div>
         </div>
       </div>
@@ -282,11 +283,4 @@ export default function UnpaidInvoicesList() {
       )}
     </div>
   );
-}
-
-function formatCurrency(amount: number): string {
-  return new Intl.NumberFormat("de-DE", {
-    style: "currency",
-    currency: "EUR",
-  }).format(amount);
 }

--- a/src/components/YearSelector.tsx
+++ b/src/components/YearSelector.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ChevronLeft, ChevronRight, Calendar } from "lucide-react";
+import { formatCurrency } from "../lib/utils";
 
 interface YearStats {
   totalRevenue: number;
@@ -21,12 +22,6 @@ export default function YearSelector({
   yearlyStats,
   onYearChange,
 }: YearSelectorProps) {
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat("de-DE", {
-      style: "currency",
-      currency: "EUR",
-    }).format(amount);
-  };
 
   return (
     <div className="bg-white rounded-lg shadow-sm p-4">
@@ -70,7 +65,7 @@ export default function YearSelector({
               Total Revenue
             </div>
             <div className="text-lg font-semibold text-gray-900">
-              {formatCurrency(yearlyStats[currentYear].totalRevenue)}
+              {formatCurrency(yearlyStats[currentYear].totalRevenue, { locale: 'de-DE', currency: 'EUR' })}
             </div>
           </div>
 
@@ -79,7 +74,7 @@ export default function YearSelector({
               Total Commissions
             </div>
             <div className="text-lg font-semibold text-gray-900">
-              {formatCurrency(yearlyStats[currentYear].totalCommissions)}
+              {formatCurrency(yearlyStats[currentYear].totalCommissions, { locale: 'de-DE', currency: 'EUR' })}
             </div>
           </div>
 

--- a/src/components/year-management/AnnualOverview.tsx
+++ b/src/components/year-management/AnnualOverview.tsx
@@ -24,6 +24,7 @@ import {
   Download,
   Maximize2,
 } from "lucide-react";
+import { formatCurrency } from "../../lib/utils";
 import HistoricalAnalytics from "./HistoricalAnalytics";
 
 interface StatCardProps {
@@ -118,13 +119,7 @@ export default function AnnualOverview() {
   const { currentYear, yearlyStats } = useYear();
   const { invoices } = useInvoices();
 
-  // Format currency
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat("de-DE", {
-      style: "currency",
-      currency: "EUR",
-    }).format(amount);
-  };
+
 
   // Calculate monthly data
   const monthlyData = React.useMemo(() => {
@@ -202,16 +197,14 @@ export default function AnnualOverview() {
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
         <StatCard
           title="Annual Revenue"
-          value={formatCurrency(yearlyStats[currentYear]?.totalRevenue || 0)}
+          value={formatCurrency(yearlyStats[currentYear]?.totalRevenue || 0, { locale: 'de-DE', currency: 'EUR' })}
           icon={Euro}
           change={yearlyStats[currentYear]?.yearOverYearGrowth}
           subText="Total revenue for the year"
         />
         <StatCard
           title="Annual Commissions"
-          value={formatCurrency(
-            yearlyStats[currentYear]?.totalCommissions || 0,
-          )}
+          value={formatCurrency(yearlyStats[currentYear]?.totalCommissions || 0, { locale: 'de-DE', currency: 'EUR' })}
           icon={TrendingUp}
           change={yearlyStats[currentYear]?.yearOverYearGrowth}
           subText="Total commissions earned"
@@ -224,9 +217,7 @@ export default function AnnualOverview() {
         />
         <StatCard
           title="Average Monthly Revenue"
-          value={formatCurrency(
-            (yearlyStats[currentYear]?.totalRevenue || 0) / 12,
-          )}
+          value={formatCurrency((yearlyStats[currentYear]?.totalRevenue || 0) / 12, { locale: 'de-DE', currency: 'EUR' })}
           icon={Calendar}
           subText="Monthly revenue average"
         />
@@ -245,7 +236,7 @@ export default function AnnualOverview() {
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="month" />
               <YAxis />
-              <Tooltip formatter={(value: number) => formatCurrency(value)} />
+              <Tooltip formatter={(value: number) => formatCurrency(value as number, { locale: 'de-DE', currency: 'EUR' })} />
               <Legend />
               <Area
                 type="monotone"
@@ -278,7 +269,7 @@ export default function AnnualOverview() {
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="quarter" />
               <YAxis />
-              <Tooltip formatter={(value: number) => formatCurrency(value)} />
+              <Tooltip formatter={(value: number) => formatCurrency(value as number, { locale: 'de-DE', currency: 'EUR' })} />
               <Legend />
               <Bar
                 dataKey="revenue"
@@ -308,7 +299,7 @@ export default function AnnualOverview() {
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="month" />
             <YAxis />
-            <Tooltip formatter={(value: number) => formatCurrency(value)} />
+            <Tooltip formatter={(value: number) => formatCurrency(value as number, { locale: 'de-DE', currency: 'EUR' })} />
             <Legend />
             <Line
               type="monotone"

--- a/src/components/year-management/HistoricalAnalytics.tsx
+++ b/src/components/year-management/HistoricalAnalytics.tsx
@@ -16,6 +16,7 @@ import {
   Bar,
 } from "recharts";
 import { TrendingUp, ArrowUpRight, ArrowDownRight } from "lucide-react";
+import { formatCurrency } from "../../lib/utils";
 
 interface TrendCardProps {
   title: string;
@@ -165,11 +166,7 @@ export default function HistoricalAnalytics() {
     };
   }, [invoices, currentYear]);
 
-  const formatCurrency = (amount: number) =>
-    new Intl.NumberFormat("de-DE", {
-      style: "currency",
-      currency: "EUR",
-    }).format(amount);
+
 
   const formatPercentage = (value: number) => `${value.toFixed(1)}%`;
   const formatNumber = (value: number) => value.toString();
@@ -187,14 +184,14 @@ export default function HistoricalAnalytics() {
           currentValue={yearlyComparison.revenue.current}
           previousValue={yearlyComparison.revenue.previous}
           percentageChange={yearlyComparison.revenue.change}
-          formatter={formatCurrency}
+          formatter={(value: number) => formatCurrency(value, { locale: 'de-DE', currency: 'EUR' })}
         />
         <TrendCard
           title="Annual Commissions"
           currentValue={yearlyComparison.commissions.current}
           previousValue={yearlyComparison.commissions.previous}
           percentageChange={yearlyComparison.commissions.change}
-          formatter={formatCurrency}
+          formatter={(value: number) => formatCurrency(value, { locale: 'de-DE', currency: 'EUR' })}
         />
         <TrendCard
           title="Average Commission Rate"
@@ -227,7 +224,9 @@ export default function HistoricalAnalytics() {
                 <YAxis yAxisId="right" orientation="right" />
                 <Tooltip
                   formatter={(value: number) =>
-                    typeof value === "number" ? formatCurrency(value) : value
+                    typeof value === 'number'
+                      ? formatCurrency(value, { locale: 'de-DE', currency: 'EUR' })
+                      : value
                   }
                 />
                 <Legend />

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,11 +5,35 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-export function formatCurrency(amount: number): string {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-  }).format(amount)
+export interface FormatCurrencyOptions {
+  locale?: string
+  currency?: string
+  minimumFractionDigits?: number
+  maximumFractionDigits?: number
+  showCurrency?: boolean
+}
+
+export function formatCurrency(
+  amount: number,
+  {
+    locale = 'en-US',
+    currency = 'USD',
+    minimumFractionDigits,
+    maximumFractionDigits,
+    showCurrency = true,
+  }: FormatCurrencyOptions = {}
+): string {
+  const options: Intl.NumberFormatOptions = {
+    minimumFractionDigits,
+    maximumFractionDigits,
+  }
+
+  if (showCurrency) {
+    options.style = 'currency'
+    options.currency = currency
+  }
+
+  return new Intl.NumberFormat(locale, options).format(amount)
 }
 
 export function formatDate(date: Date | string): string {
@@ -52,7 +76,7 @@ export function isObjectEmpty(obj: Record<string, unknown>): boolean {
   return Object.keys(obj).length === 0
 }
 
-export function debounce<T extends (...args: any[]) => any>(
+export function debounce<T extends (...args: unknown[]) => unknown>(
   func: T,
   wait: number
 ): (...args: Parameters<T>) => void {
@@ -69,7 +93,7 @@ export function debounce<T extends (...args: any[]) => any>(
   }
 }
 
-export function throttle<T extends (...args: any[]) => any>(
+export function throttle<T extends (...args: unknown[]) => unknown>(
   func: T,
   limit: number
 ): (...args: Parameters<T>) => void {

--- a/src/services/firebaseServices.ts
+++ b/src/services/firebaseServices.ts
@@ -5,15 +5,12 @@ import {
   addDoc, 
   updateDoc, 
   deleteDoc, 
-  getDocs, 
-  getDoc, 
-  query, 
-  where, 
-  orderBy, 
+  getDocs,
+  query,
+  where,
+  orderBy,
   serverTimestamp,
-  setDoc,
-  DocumentReference,
-  DocumentData
+  
 } from 'firebase/firestore';
 import { db } from '../config/firebase';
 import type { Invoice, SettlementStatus, FirmType } from '../types';


### PR DESCRIPTION
## Summary
- refine currency formatting utils and quarterly views
- clean up unused imports and types
- better type handling across forms and firebase services

## Testing
- `npm run lint` *(fails: 50 errors)*

------
https://chatgpt.com/codex/tasks/task_e_683feebf5e24832084e5b50fb51b1f7e