### PR TITLE
Configure Netlify secrets scan

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,9 @@
   command = "npm run build"
   publish = "dist"
 
+[build.environment]
+  SECRETS_SCAN_SMART_DETECTION_ENABLED = "false"
+
 [[redirects]]
   from = "/*"
   to = "/index.html"


### PR DESCRIPTION
## Summary
- disable Netlify's smart detection secrets scanning step via environment variable

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm install` *(fails: process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_6863d2ff73e483209dbad8d68d1cf91a