### PR TITLE
Add firm theme customization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { InvoiceProvider } from "./context/InvoiceContext";
 import { YearProvider } from "./context/YearContext";
 import { CommissionProvider } from "./context/CommissionContext";
 import { ClientProvider } from "./context/ClientContext";
+import { ThemeProvider } from "./context/ThemeContext";
 import LoginForm from "./components/LoginForm";
 import Dashboard from "./components/Dashboard";
 import { useAuth } from "./context/AuthContext";
@@ -39,15 +40,15 @@ function AuthenticatedApp({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <InvoiceProvider>
-      <YearProvider>
-        <ClientProvider>
-          <CommissionProvider>
-            {children}
-          </CommissionProvider>
-        </ClientProvider>
-      </YearProvider>
-    </InvoiceProvider>
+    <ThemeProvider>
+      <InvoiceProvider>
+        <YearProvider>
+          <ClientProvider>
+            <CommissionProvider>{children}</CommissionProvider>
+          </ClientProvider>
+        </YearProvider>
+      </InvoiceProvider>
+    </ThemeProvider>
   );
 }
 

--- a/src/components/AdminFirmSettings.tsx
+++ b/src/components/AdminFirmSettings.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+import { useTheme } from '../context/ThemeContext';
+import { firmServices } from '../services/firmServices';
+import type { FirmTheme } from '../types';
+
+export default function AdminFirmSettings() {
+  const { user } = useAuth();
+  const { theme, refresh } = useTheme();
+  const [form, setForm] = useState<FirmTheme | null>(null);
+  const [logoFile, setLogoFile] = useState<File | null>(null);
+
+  useEffect(() => {
+    if (theme) setForm(theme);
+  }, [theme]);
+
+  if (!user || !form) return null;
+
+  const handleSave = async () => {
+    if (logoFile) {
+      const url = await firmServices.uploadLogo(user.firm, logoFile);
+      form.logoUrl = url;
+    }
+    await firmServices.updateFirmConfig(user.firm, form);
+    await refresh();
+    alert('Settings saved');
+  };
+
+  const updateField = (field: keyof FirmTheme, value: string) => {
+    setForm({ ...form, [field]: value });
+  };
+
+  return (
+    <div className="p-4 bg-white rounded shadow space-y-4">
+      <h2 className="text-lg font-medium">Firm Settings</h2>
+      {form.logoUrl && (
+        <img src={form.logoUrl} alt="logo" className="h-12" />
+      )}
+      <input
+        type="file"
+        accept="image/*"
+        onChange={(e) => setLogoFile(e.target.files?.[0] || null)}
+      />
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm mb-1">Primary</label>
+          <input
+            type="color"
+            value={form.primary}
+            onChange={(e) => updateField('primary', e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Secondary</label>
+          <input
+            type="color"
+            value={form.secondary}
+            onChange={(e) => updateField('secondary', e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Text</label>
+          <input
+            type="color"
+            value={form.text}
+            onChange={(e) => updateField('text', e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Accent</label>
+          <input
+            type="color"
+            value={form.accent}
+            onChange={(e) => updateField('accent', e.target.value)}
+          />
+        </div>
+      </div>
+      <button
+        className="px-4 py-2 bg-indigo-600 text-white rounded"
+        onClick={handleSave}
+      >
+        Save
+      </button>
+    </div>
+  );
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { Disclosure, Transition } from "@headlessui/react";
 import { useAuth } from "../context/AuthContext";
 import { useYear } from "../context/YearContext";
+import { useTheme } from "../context/ThemeContext";
 import { LogOut, Trash2, AlertTriangle, ChevronDown, Euro } from "lucide-react";
 import InvoiceForm from "./InvoiceForm";
 import InvoiceList from "./InvoiceList";
@@ -10,41 +11,15 @@ import UnpaidInvoicesList from "./UnpaidInvoicesList";
 import DashboardCharts from "./DashboardCharts";
 import type { FirmType } from "../types";
 
-const firmThemes = {
-  SKALLARS: {
-    primary: "bg-purple-100",
-    secondary: "bg-purple-50",
-    text: "text-purple-600",
-    border: "border-purple-200",
-    light: "text-purple-500",
-    accent: "#9333ea",
-  },
-  MKMs: {
-    primary: "bg-blue-100",
-    secondary: "bg-blue-50",
-    text: "text-blue-600",
-    border: "border-blue-200",
-    light: "text-blue-500",
-    accent: "#2563eb",
-  },
-  Contax: {
-    primary: "bg-yellow-100",
-    secondary: "bg-yellow-50",
-    text: "text-yellow-600",
-    border: "border-yellow-200",
-    light: "text-yellow-500",
-    accent: "#d97706",
-  },
-} as const;
-
 export default function Dashboard() {
   const { user, logout } = useAuth();
   const { currentYear, currentQuarter } = useYear();
+  const { theme } = useTheme();
   const [showResetConfirmation, setShowResetConfirmation] = useState(false);
 
   if (!user) return null;
 
-  const firmTheme = firmThemes[user.firm as FirmType];
+  const firmTheme = theme;
 
   const quarterLabel = `Q${currentQuarter} ${currentYear}`;
   const quarterRange = {
@@ -58,13 +33,16 @@ export default function Dashboard() {
   })}`;
 
   return (
-    <div className={`min-h-screen ${firmTheme.secondary}`}>
+    <div className="min-h-screen" style={{ backgroundColor: firmTheme?.secondary }}>
       {/* Header */}
-      <header className="bg-white shadow-sm">
+      <header className="shadow-sm" style={{ backgroundColor: firmTheme?.primary }}>
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-4">
             <div className="flex items-center">
-              <h1 className={`text-2xl font-semibold ${firmTheme.text}`}>
+              {firmTheme?.logoUrl && (
+                <img src={firmTheme.logoUrl} alt="logo" className="h-8 w-8 mr-2" />
+              )}
+              <h1 className="text-2xl font-semibold" style={{ color: firmTheme?.text }}>
                 {user.firm} Commission Dashboard
               </h1>
               <span className="ml-4 px-3 py-1 rounded-md bg-gray-100 text-gray-600 text-sm">

--- a/src/config/themes.ts
+++ b/src/config/themes.ts
@@ -1,0 +1,31 @@
+import type { FirmType, FirmTheme } from '../types';
+
+export const defaultFirmThemes: Record<FirmType, FirmTheme> = {
+  SKALLARS: {
+    primary: '#f3e8ff',
+    secondary: '#faf5ff',
+    text: '#9333ea',
+    border: '#e9d5ff',
+    light: '#a855f7',
+    accent: '#9333ea',
+    logoUrl: '',
+  },
+  MKMs: {
+    primary: '#dbeafe',
+    secondary: '#eff6ff',
+    text: '#2563eb',
+    border: '#bfdbfe',
+    light: '#3b82f6',
+    accent: '#2563eb',
+    logoUrl: '',
+  },
+  Contax: {
+    primary: '#fef9c3',
+    secondary: '#fefce8',
+    text: '#d97706',
+    border: '#fef08a',
+    light: '#eab308',
+    accent: '#d97706',
+    logoUrl: '',
+  },
+};

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,42 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { useAuth } from './AuthContext';
+import { firmServices } from '../services/firmServices';
+import { defaultFirmThemes } from '../config/themes';
+import type { FirmTheme } from '../types';
+
+interface ThemeContextType {
+  theme: FirmTheme | null;
+  refresh: () => Promise<void>;
+}
+
+const ThemeContext = createContext<ThemeContextType>({
+  theme: null,
+  refresh: async () => {},
+});
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const { user } = useAuth();
+  const [theme, setTheme] = useState<FirmTheme | null>(null);
+
+  const loadTheme = async () => {
+    if (user) {
+      const cfg = await firmServices.getFirmConfig(user.firm);
+      const merged = { ...defaultFirmThemes[user.firm], ...(cfg || {}) };
+      setTheme(merged);
+    }
+  };
+
+  useEffect(() => {
+    loadTheme();
+  }, [user]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, refresh: loadTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/src/services/firmServices.ts
+++ b/src/services/firmServices.ts
@@ -1,0 +1,27 @@
+import { collection, doc, getDoc, setDoc } from 'firebase/firestore';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { db, storage } from '../config/firebase';
+import type { FirmType, FirmTheme } from '../types';
+
+const firmsCollection = collection(db, 'firms');
+
+export const firmServices = {
+  getFirmConfig: async (firm: FirmType): Promise<FirmTheme | null> => {
+    const firmRef = doc(firmsCollection, firm);
+    const snap = await getDoc(firmRef);
+    return snap.exists() ? (snap.data() as FirmTheme) : null;
+  },
+
+  updateFirmConfig: async (firm: FirmType, data: Partial<FirmTheme>) => {
+    const firmRef = doc(firmsCollection, firm);
+    await setDoc(firmRef, data, { merge: true });
+  },
+
+  uploadLogo: async (firm: FirmType, file: File): Promise<string> => {
+    const storageRef = ref(storage, `logos/${firm}/${file.name}`);
+    await uploadBytes(storageRef, file);
+    const url = await getDownloadURL(storageRef);
+    await firmServices.updateFirmConfig(firm, { logoUrl: url });
+    return url;
+  },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,3 +18,13 @@ export interface SettlementStatus {
   settledAt?: string;  // When the commission was marked as settled
   settledBy: FirmType;  // The firm that marked the commission as settled
 }
+
+export interface FirmTheme {
+  logoUrl?: string;
+  primary: string;
+  secondary: string;
+  text: string;
+  border?: string;
+  light?: string;
+  accent: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,3 +28,13 @@ export interface SettlementStatus {
   updatedAt: Date;
   createdAt?: Date;
 }
+
+export interface FirmTheme {
+  logoUrl?: string;
+  primary: string;
+  secondary: string;
+  text: string;
+  border?: string;
+  light?: string;
+  accent: string;
+}


### PR DESCRIPTION
## Summary
- add `FirmTheme` interface to share color and logo details
- centralize default firm themes
- create `ThemeProvider` and hook for accessing firm theme
- support logo and colors through `firmServices`
- add admin UI component for adjusting firm settings
- use ThemeProvider in Dashboard and App

## Testing
- `npx tsc -p tsconfig.json`
- `npm run lint` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6863f84ad4e483208fbce1cbece2f53b