### PR TITLE
Centralize firm themes

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -9,33 +9,7 @@ import QuarterlySnapshot from "./QuarterlySnapshot";
 import UnpaidInvoicesList from "./UnpaidInvoicesList";
 import DashboardCharts from "./DashboardCharts";
 import type { FirmType } from "../types";
-
-const firmThemes = {
-  SKALLARS: {
-    primary: "bg-purple-100",
-    secondary: "bg-purple-50",
-    text: "text-purple-600",
-    border: "border-purple-200",
-    light: "text-purple-500",
-    accent: "#9333ea",
-  },
-  MKMs: {
-    primary: "bg-blue-100",
-    secondary: "bg-blue-50",
-    text: "text-blue-600",
-    border: "border-blue-200",
-    light: "text-blue-500",
-    accent: "#2563eb",
-  },
-  Contax: {
-    primary: "bg-yellow-100",
-    secondary: "bg-yellow-50",
-    text: "text-yellow-600",
-    border: "border-yellow-200",
-    light: "text-yellow-500",
-    accent: "#d97706",
-  },
-} as const;
+import { firmThemes } from "../config/themes";
 
 export default function Dashboard() {
   const { user, logout } = useAuth();

--- a/src/components/DashboardCharts.tsx
+++ b/src/components/DashboardCharts.tsx
@@ -27,27 +27,7 @@ import {
   ArrowDownRight,
 } from "lucide-react";
 import type { FirmType } from "../types";
-
-const firmThemes = {
-  SKALLARS: {
-    primary: "#9333ea",
-    secondary: "#a855f7",
-    tertiary: "#c084fc",
-    light: "#f3e8ff",
-  },
-  MKMs: {
-    primary: "#2563eb",
-    secondary: "#3b82f6",
-    tertiary: "#60a5fa",
-    light: "#e0f2fe",
-  },
-  Contax: {
-    primary: "#d97706",
-    secondary: "#f59e0b",
-    tertiary: "#fbbf24",
-    light: "#fef3c7",
-  },
-} as const;
+import { firmThemes } from "../config/themes";
 
 interface ChartMetric {
   label: string;

--- a/src/components/InvoiceList.tsx
+++ b/src/components/InvoiceList.tsx
@@ -15,27 +15,7 @@ import {
   ChevronUp,
 } from "lucide-react";
 import type { FirmType, Invoice } from "../types";
-
-const firmThemes = {
-  SKALLARS: {
-    bg: "bg-purple-50",
-    border: "border-purple-200",
-    text: "text-purple-600",
-    hover: "hover:bg-purple-100",
-  },
-  MKMs: {
-    bg: "bg-blue-50",
-    border: "border-blue-200",
-    text: "text-blue-600",
-    hover: "hover:bg-blue-100",
-  },
-  Contax: {
-    bg: "bg-yellow-50",
-    border: "border-yellow-200",
-    text: "text-yellow-600",
-    hover: "hover:bg-yellow-100",
-  },
-} as const;
+import { firmThemes } from "../config/themes";
 
 interface FilterState {
   search: string;

--- a/src/components/QuarterlySummary.tsx
+++ b/src/components/QuarterlySummary.tsx
@@ -3,33 +3,7 @@ import { useInvoices } from "../context/InvoiceContext";
 import { useAuth } from "../context/AuthContext";
 import { ArrowRight, Euro, Clock, Check } from "lucide-react";
 import type { FirmType } from "../types";
-
-const firmThemes = {
-  SKALLARS: {
-    primary: "bg-purple-100",
-    secondary: "bg-purple-50",
-    text: "text-purple-600",
-    accent: "bg-purple-600",
-    border: "border-purple-200",
-    gradient: "from-purple-50 to-purple-100",
-  },
-  MKMs: {
-    primary: "bg-gray-100",
-    secondary: "bg-gray-50",
-    text: "text-gray-600",
-    accent: "bg-gray-600",
-    border: "border-gray-200",
-    gradient: "from-gray-50 to-gray-100",
-  },
-  Contax: {
-    primary: "bg-yellow-100",
-    secondary: "bg-yellow-50",
-    text: "text-yellow-600",
-    accent: "bg-yellow-600",
-    border: "border-yellow-200",
-    gradient: "from-yellow-50 to-yellow-100",
-  },
-};
+import { firmThemes } from "../config/themes";
 
 interface QuarterlyData {
   quarter: string;

--- a/src/components/RecentInvoices.tsx
+++ b/src/components/RecentInvoices.tsx
@@ -9,24 +9,7 @@ import {
   Clock,
 } from "lucide-react";
 import type { FirmType } from "../types";
-
-const firmThemes = {
-  SKALLARS: {
-    text: "text-purple-600",
-    bg: "bg-purple-50",
-    border: "border-purple-200",
-  },
-  MKMs: {
-    text: "text-blue-600",
-    bg: "bg-blue-50",
-    border: "border-blue-200",
-  },
-  Contax: {
-    text: "text-yellow-600",
-    bg: "bg-yellow-50",
-    border: "border-yellow-200",
-  },
-} as const;
+import { firmThemes } from "../config/themes";
 
 interface RecentInvoiceProps {
   clientName: string;

--- a/src/config/themes.ts
+++ b/src/config/themes.ts
@@ -1,0 +1,51 @@
+export const firmThemes = {
+  SKALLARS: {
+    primary: "bg-purple-100",
+    secondary: "bg-purple-50",
+    text: "text-purple-600",
+    border: "border-purple-200",
+    light: "text-purple-500",
+    accent: "#9333ea",
+    bg: "bg-purple-50",
+    hover: "hover:bg-purple-100",
+    chartPrimary: "#9333ea",
+    chartSecondary: "#a855f7",
+    chartTertiary: "#c084fc",
+    chartLight: "#f3e8ff",
+    gradient: "from-purple-50 to-purple-100",
+  },
+  MKMs: {
+    primary: "bg-blue-100",
+    secondary: "bg-blue-50",
+    text: "text-blue-600",
+    border: "border-blue-200",
+    light: "text-blue-500",
+    accent: "#2563eb",
+    bg: "bg-blue-50",
+    hover: "hover:bg-blue-100",
+    chartPrimary: "#2563eb",
+    chartSecondary: "#3b82f6",
+    chartTertiary: "#60a5fa",
+    chartLight: "#e0f2fe",
+    gradient: "from-gray-50 to-gray-100",
+  },
+  Contax: {
+    primary: "bg-yellow-100",
+    secondary: "bg-yellow-50",
+    text: "text-yellow-600",
+    border: "border-yellow-200",
+    light: "text-yellow-500",
+    accent: "#d97706",
+    bg: "bg-yellow-50",
+    hover: "hover:bg-yellow-100",
+    chartPrimary: "#d97706",
+    chartSecondary: "#f59e0b",
+    chartTertiary: "#fbbf24",
+    chartLight: "#fef3c7",
+    gradient: "from-yellow-50 to-yellow-100",
+  },
+} as const;
+
+export type FirmThemes = typeof firmThemes;
+export type FirmTheme = FirmThemes[keyof FirmThemes];
+


### PR DESCRIPTION
## Summary
- add `src/config/themes.ts` with all firm color definitions
- refactor various components to import `firmThemes`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6863f84afce88320b1f21b9964b03791