### PR TITLE
Fix duplicate warning in Firebase guide

### DIFF
--- a/FIREBASE_SETUP.md
+++ b/FIREBASE_SETUP.md
@@ -83,8 +83,6 @@ service cloud.firestore {
 
 **IMPORTANT**: After entering these rules, click the "Publish" button to deploy them. If you don't publish the rules, they won't take effect and you'll encounter permission errors.
 
-**IMPORTANT**: After entering these rules, click the "Publish" button to deploy them. If you don't publish the rules, they won't take effect and you'll encounter permission errors.
-```
 
 ## Data Migration
 


### PR DESCRIPTION
## Summary
- remove duplicate Important note in `FIREBASE_SETUP.md`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6863f84cc78c8320906d9f829bbccb8d