### PR TITLE
Restrict settlement writes to firm

### DIFF
--- a/FIREBASE_SETUP.md
+++ b/FIREBASE_SETUP.md
@@ -73,9 +73,16 @@ service cloud.firestore {
       allow read, write: if request.auth != null;
     }
     
-    // Allow authenticated users to read and write settlements
+    // Allow authenticated users to read settlements
+    // Only the firm eligible to receive a commission can mark it as settled
     match /settlements/{settlementId} {
-      allow read, write: if request.auth != null;
+      allow read: if request.auth != null;
+      allow create: if request.auth != null &&
+        request.resource.data.settledBy ==
+        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.firm;
+      allow update, delete: if request.auth != null &&
+        resource.data.settledBy ==
+        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.firm;
     }
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -16,9 +16,18 @@ service cloud.firestore {
       allow read, write: if request.auth != null;
     }
     
-    // Allow authenticated users to read and write settlements
+    // Allow authenticated users to read settlements
+    // Restrict settlement writes so only the firm receiving the commission can
+    // mark it as settled. The `settledBy` field must match the user's firm
+    // stored in their `/users/{uid}` document.
     match /settlements/{settlementId} {
-      allow read, write: if request.auth != null;
+      allow read: if request.auth != null;
+      allow create: if request.auth != null &&
+        request.resource.data.settledBy ==
+        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.firm;
+      allow update, delete: if request.auth != null &&
+        resource.data.settledBy ==
+        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.firm;
     }
   }
 }


### PR DESCRIPTION
## Summary
- restrict `settlements` writes in Firestore rules so only the receiving firm can mark commissions as settled
- update Firebase setup docs with the new security rules

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6863ff2133f883209e1bee7f514151ee