### PR TITLE
Add settings modal for firm customization

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -3,12 +3,13 @@ import { Disclosure, Transition } from "@headlessui/react";
 import { useAuth } from "../context/AuthContext";
 import { useYear } from "../context/YearContext";
 import { useTheme } from "../context/ThemeContext";
-import { LogOut, Trash2, AlertTriangle, ChevronDown, Euro } from "lucide-react";
+import { LogOut, Trash2, AlertTriangle, ChevronDown, Euro, Settings as SettingsIcon, X } from "lucide-react";
 import InvoiceForm from "./InvoiceForm";
 import InvoiceList from "./InvoiceList";
 import QuarterlySnapshot from "./QuarterlySnapshot";
 import UnpaidInvoicesList from "./UnpaidInvoicesList";
 import DashboardCharts from "./DashboardCharts";
+import AdminFirmSettings from "./AdminFirmSettings";
 import type { FirmType } from "../types";
 
 export default function Dashboard() {
@@ -16,6 +17,7 @@ export default function Dashboard() {
   const { currentYear, currentQuarter } = useYear();
   const { theme } = useTheme();
   const [showResetConfirmation, setShowResetConfirmation] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
 
   if (!user) return null;
 
@@ -66,6 +68,13 @@ export default function Dashboard() {
               >
                 <Trash2 className="h-4 w-4 mr-2" />
                 Reset Data
+              </button>
+              <button
+                onClick={() => setShowSettings(true)}
+                className="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-white bg-gray-600 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+              >
+                <SettingsIcon className="h-4 w-4 mr-2" />
+                Settings
               </button>
               <button
                 onClick={logout}
@@ -185,6 +194,23 @@ export default function Dashboard() {
                 </button>
               </div>
             </div>
+          </div>
+        </div>
+      )}
+      {/* Settings Modal */}
+      {showSettings && (
+        <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50">
+          <div className="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white">
+            <div className="flex justify-between items-start mb-4">
+              <h2 className="text-lg font-medium">Firm Settings</h2>
+              <button
+                onClick={() => setShowSettings(false)}
+                className="text-gray-400 hover:text-gray-500"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            <AdminFirmSettings />
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- add Settings button in dashboard header
- import AdminFirmSettings in Dashboard
- show AdminFirmSettings in a modal overlay for customizing firm theme

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68641099d8788320a2aff98b767a21bf